### PR TITLE
Page Extractor

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -50,7 +50,7 @@
         "activeTab",
         "storage",
         "https://boilerpipe-web.appspot.com/*",
-        "https://mercury.postlight.com/*"
+        "https://mercury.postlight.com/*",
         "http://*/",
         "https://*/"
     ],

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -11,6 +11,7 @@
     "background": {
         "scripts": [
             "scripts/chromereload.js",
+            "bower_components/jquery/dist/jquery.js",
             "scripts/background.js"
         ],
         "persistent": false
@@ -50,6 +51,8 @@
         "storage",
         "https://boilerpipe-web.appspot.com/*",
         "https://mercury.postlight.com/*"
+        "http://*/",
+        "https://*/"
     ],
     "options_page": "options.html"
 }

--- a/app/options.html
+++ b/app/options.html
@@ -39,6 +39,13 @@
                         </a>
                         <input type="text" class="form-control input-lg" id="mercuryAPIKey" placeholder="Mercury API Key">
                     </div>
+                    <div class="form-group" id="pageExtractorForm">
+                        <label for="pageExtractor" data-message="optionsPageExtractor">Page Extractor</label>
+                        <a class="pull-right" data-toggle="modal" data-target="#mercuryHelp" href="#" data-message="optionsHelp">
+                            Help
+                        </a>
+                        <textarea class="form-control input-lg" id="pageExtractor" placeholder="sitename.com=selector css"></textarea>
+                    </div>
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" id="enableShortcut"> <span data-message="optionsEnableKeyboardShortcut">Enable keyboard shortcut</span> <code>f f</code>

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -9,7 +9,7 @@ function printResponse(response) {
     console.log('Content response:\n' + response);
 }
 
-/* Regex-pattern to check URLs against. 
+/* Regex-pattern to check URLs against.
    It matches URLs like: http[s]://[...]feedly.com[...] */
 var urlRegex = /^https?:\/\/(?:[^\.]+\.)?feedly\.com/;
 
@@ -17,7 +17,7 @@ var urlRegex = /^https?:\/\/(?:[^\.]+\.)?feedly\.com/;
 chrome.pageAction.onClicked.addListener(function(tab) {
     // ...check the URL of the active tab against our pattern and...
     if (urlRegex.test(tab.url)) {
-        // ...if it matches, send a message specifying a callback too 
+        // ...if it matches, send a message specifying a callback too
         chrome.tabs.sendMessage(tab.id, { text: 'extract_article' }, printResponse);
     }
 });
@@ -40,6 +40,43 @@ chrome.runtime.onInstalled.addListener(function() {
             }
         ]);
     });
+});
+function articleExtractorRequest(xhr, sendResponse, selector) {
+    return function() {
+        if (xhr.readyState === 4) {
+            if (xhr.status === 200) {
+                // Operation succeded
+
+                    // Get the content of the article
+                var articleContent = $(xhr.responseText).find(selector || 'body').html();
+                if (!articleContent) {
+                  console.log('[FullyFeedly] There is something wrong: no content found for the selector '+ selector);
+                  sendResponse({error:'selectorNotFound'});
+                }
+                sendResponse({content:articleContent, selector: selector});
+            } else if (xhr.status === 503) {
+                console.log('[FullyFeedly] Boilerpipe API exceeded quota');
+                sendResponse({error:'APIOverQuota'});
+            } else {
+                console.log('[FullyFeedly] Failed to load the content of the page');
+                sendResponse({error:'articleNotFound'});
+            }
+        }
+    };
+}
+
+chrome.runtime.onMessage.addListener(
+  function(request, sender, sendResponse) {
+    console.log(sender.tab ?
+                "from a content script:" + sender.tab.url :
+                "from the extension");
+    if (request.url) {
+      var xhr = new XMLHttpRequest();
+      xhr.onreadystatechange = articleExtractorRequest(xhr, sendResponse, request.selector);
+      xhr.open('GET', request.url, true);
+      xhr.send();
+    }
+    return true;
 });
 
 console.log('FullyFeedly: extension started');

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -22,11 +22,37 @@ function onKeyboardShortcut() {
     }, 500);
 }
 
+function arrayToString(array) {
+  var str = '';
+  if (Array.isArray(array) && array.length > 0) {
+    array.forEach(function(item) {
+      str += item.website + '=' + item.selector + '\n';
+    });
+  }
+  return str;
+}
+
+function stringToArray(str) {
+  var array = [];
+  var items = str.split('\n');
+  if (items) {
+    items.forEach(function(item) {
+      var parts = item.split('=');
+      if (parts.length == 2) {
+        array.push({website: parts[0], selector: parts[1]});
+      }
+    });
+  }
+  return array;
+}
+
 // Saves options to chrome.storage
 function saveOptions() {
     var extractionAPI = $('#extractionAPI').val();
     var mercuryAPIKey = $('#mercuryAPIKey').val();
     var enableShortcut = $('#enableShortcut').prop('checked');
+    var pageExtractor = stringToArray($('#pageExtractor').val());
+    console.log(pageExtractor);
     var status = $('#status');
 
     // Check optional paramenters
@@ -46,7 +72,8 @@ function saveOptions() {
     chrome.storage.sync.set({
         extractionAPI: extractionAPI,
         mercuryAPIKey: mercuryAPIKey,
-        enableShortcut: enableShortcut
+        enableShortcut: enableShortcut,
+        pageExtractor: pageExtractor
     }, function() {
         // Update status to let user know options were saved.
         status.text('Options saved');
@@ -62,7 +89,8 @@ function restoreOptions() {
     chrome.storage.sync.get({
         extractionAPI: 'Boilerpipe',
         mercuryAPIKey: '',
-        enableShortcut: false
+        enableShortcut: false,
+        pageExtractor: []
     }, function(items) {
         // In case the user has not switched to Mercury yet...
         if (items.extractionAPI === "Readability")
@@ -71,6 +99,7 @@ function restoreOptions() {
         $('#extractionAPI').val(items.extractionAPI);
         $('#mercuryAPIKey').val(items.mercuryAPIKey);
         $('#enableShortcut').prop('checked', items.enableShortcut);
+        $('#pageExtractor').val(arrayToString(items.pageExtractor))
         updateForm();
     });
 }


### PR DESCRIPTION
Load the website in background page without webservice, extract the content with a selector defined in the option page (by default the balise article).
This can keep images in the article and all other content.
Simple Configuration for configure website and selector for use the Page Extractor, if there a configuration for the website, load the site in the background page.
For site you want use the page extractor, put the site name = the css selector (by example article or .main-content).
Other site will use the other selected api (Mercury or Boilerplate).

It's an amelioration of the ArticleExtractor Pull Request #27 