### PR TITLE
Use https instead of http for better security

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Getting started
 
-Follow [this guide](http://minimul.com/developing-a-chrome-extension-with-yeoman.html) to build and debug the extension.
+Follow [this guide](https://minimul.com/developing-a-chrome-extension-with-yeoman.html) to build and debug the extension.
 
 In summary, install the required command line tools:
 
@@ -28,14 +28,14 @@ You can now [load the unpacked extension in Chrome](https://developer.chrome.com
 
 The Github repository uses a **linear** commit history.
  
-To simplify the contribution from external developers, the project moved away from the [GitFlow](http://nvie.com/posts/a-successful-git-branching-model/) branching strategy.
+To simplify the contribution from external developers, the project moved away from the [GitFlow](https://nvie.com/posts/a-successful-git-branching-model/) branching strategy.
 
 All the contributions should be submitted as pull requests to the master branch and must not contain any merge commit.
 
 
 ## Version numbers
 
-Version numbers follow the [Semantic Versioning](http://semver.org) and are managed by the owner of the project.
+Version numbers follow the [Semantic Versioning](https://semver.org) and are managed by the owner of the project.
 Please, do not increase the version numbers in your pull requests.
 
 

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ Thanks a lot to the following developers for their help and contributions:
 The text of the article is extracted using the web API provided by:
 
 * [Mercury](https://mercury.postlight.com/): **recommended**, free for non-commercial use, API key required
-* [Boilerpipe](http://boilerpipe-web.appspot.com/): free to use, limited quota
+* [Boilerpipe](https://boilerpipe-web.appspot.com/): free to use, limited quota

--- a/app/options.html
+++ b/app/options.html
@@ -48,7 +48,7 @@
                 <div class="col-md-8 col-md-offset-2">
                     <hr/>
                     <p style="text-align: right"><span data-message="optionsDevelopedBy">Developed by</span>
-                        <a href="http://linkedin.com/in/andreagrandi87">
+                        <a href="https://linkedin.com/in/andreagrandi87">
                             <img src="images/linkedin_btn_20x15.png"/>Andrea Grandi
                         </a>
                     </p>


### PR DESCRIPTION
Those links all support https, and most of them redirect to https permanently. Should better use https directly, which is more secure, and one redirection saved.